### PR TITLE
StabilizedSK - correct poles

### DIFF
--- a/polyrat/skiter_stabilized.py
+++ b/polyrat/skiter_stabilized.py
@@ -147,3 +147,12 @@ class StabilizedSKRationalApproximation(RationalApproximation, RationalRatio):
 			history = True, xtol = self.xtol, denom0 = denom0, weight = weight,
 			)
 		
+		from .basis import LegendrePolynomialBasis
+		from .polynomial import PolynomialApproximation
+		y = self.denominator
+		poly = PolynomialApproximation(self.denom_degree, Basis = LegendrePolynomialBasis)
+		poly.fit(X, y)
+		self.rat_poles = poly.roots().flatten()
+		
+
+		


### PR DESCRIPTION
The original code for obtaining **poles** from **StabilizedSKRationalApproximation** gives back wrong results, so I created a function rat_poles as an addition specifically for this approximation.
I am aware a more general correction should be made in arnoldi.py, but unfortunatelly I was unable to do that, due to complex function structure. I left the original poles() function there, if one manages to fix it. 

I am otherwise trying to use StabilizedSKRationalApproximation (SSK) for the use of calculating the poles of an experimentally obtained complex data. I couldn't help but notice, that poles are in this case calculated by fitting the denominator on a polynomial in Legendre basis; is the calculation of poles not possible from the Arnoldi polynomial basis?
As my function is univariate, I understood that the basis with StabilizedSKRationalApproximation is actually a Krylov subspace from x and weights, is it possible to yield exact poles at least in this case?

I am thankful in advance for any advice regarding finding the complex poles from SSK univariate approximation and hope we manage to solve the issue with poles from StabilizedSK.